### PR TITLE
Refactoring convertLocalizables and add support for UIStackView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,7 @@ All notable changes to the project will be documented in this file.
 
 #### API breaking changes
 
-N/A
-
-#### Enhancements
+- `UIView.convertLocalizables()` is now named `UIView.translateSubviews()`
 
 #### Enhancements
 
@@ -54,6 +52,9 @@ public func setClearButton(with image: UIImage)
 func tinted(with color: UIColor) -> UIImage?
 func combined(with image: UIImage) -> UIImage?
 ```
+
+- UIView (iOS only)
+   - Add `UIStackView` support for `translateSubviews()`
 
 #### Bugfixes
 

--- a/README.md
+++ b/README.md
@@ -1165,7 +1165,7 @@ aView.height -= 10 // make the view shorter
 **Automates your localizables**
 
 ```swift
-aView.convertLocalizables()
+aView.translateSubviews()
 ```
 
 It will iterate on all the subviews of the view, and use the text / placeholder as key in `NSLocalizedString`.

--- a/Source/iOS/UIViewExtension.swift
+++ b/Source/iOS/UIViewExtension.swift
@@ -11,34 +11,34 @@ import UIKit
 public extension UIView {
 
     // swiftlint:disable:next cyclomatic_complexity
-    public func convertLocalizables() {
+    public func translateSubviews() {
         if subviews.isEmpty {
             return
         }
 
-        for aSubview: UIView in subviews {
-            if let aLabel = aSubview as? UILabel {
-                if let text = aLabel.text {
-                    aLabel.text = NSLocalizedString(text, comment: "")
-                }
-            } else if let aTextField = aSubview as? UITextField {
-                if let text = aTextField.text {
-                    aTextField.text = NSLocalizedString(text, comment: "")
-                }
-                if let placeholder = aTextField.placeholder {
-                    aTextField.placeholder = NSLocalizedString(placeholder, comment: "")
-                }
-            } else if let aTextView = aSubview as? UITextView {
-                if let text = aTextView.text {
-                    aTextView.text = NSLocalizedString(text, comment: "")
-                }
-            } else if let aButton = aSubview as?  UIButton {
-                if let title = aButton.title(for: []) {
-                    aButton.setTitle(NSLocalizedString(title, comment: ""), for: [])
+        for subview in subviews {
+            translate(subview)
+            if #available(iOS 9.0, *), let stackView = subview as? UIStackView {
+                stackView.arrangedSubviews.forEach {
+                    self.translate($0)
+                    $0.translateSubviews()
                 }
             } else {
-                aSubview.convertLocalizables()
+                subview.translateSubviews()
             }
+        }
+    }
+
+    private func translate(_ subview: UIView) {
+        if let label = subview as? UILabel {
+            label.text = NSLocalizedString(label.text ?? "", comment: "")
+        } else if let textField = subview as? UITextField {
+            textField.text = NSLocalizedString(textField.text ?? "", comment: "")
+            textField.placeholder = NSLocalizedString(textField.placeholder ?? "", comment: "")
+        } else if let textView = subview as? UITextView {
+            textView.text = NSLocalizedString(textView.text, comment: "")
+        } else if let button = subview as? UIButton {
+            button.setTitle(NSLocalizedString(button.title(for: .normal) ?? "", comment: ""), for: .normal)
         }
     }
 

--- a/SwiftyUtils Example/iOS Example/Classes/GesturesExampleViewController.swift
+++ b/SwiftyUtils Example/iOS Example/Classes/GesturesExampleViewController.swift
@@ -47,7 +47,7 @@ class GesturesExampleViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.convertLocalizables()
+        view.translateSubviews()
         self.handleTapGesture()
         self.handleLongPressGesture()
         self.handleSwipeGesture()

--- a/SwiftyUtils Example/iOS Example/Classes/LocalizablesExampleViewController.swift
+++ b/SwiftyUtils Example/iOS Example/Classes/LocalizablesExampleViewController.swift
@@ -9,7 +9,7 @@ class LocalizablesExampleViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.convertLocalizables()
+        view.translateSubviews()
     }
 
 }

--- a/SwiftyUtils Example/iOS Example/Classes/Main.storyboard
+++ b/SwiftyUtils Example/iOS Example/Classes/Main.storyboard
@@ -232,15 +232,39 @@
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="R2g-9P-TkA">
+                                <rect key="frame" x="67.5" y="395" width="240" height="100.5"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="localizables_example.stackview.label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="W7V-dV-SSQ">
+                                        <rect key="frame" x="0.0" y="0.0" width="240" height="20.5"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nnL-NO-ZE0">
+                                        <rect key="frame" x="0.0" y="30.5" width="240" height="30"/>
+                                        <state key="normal" title="localizables_example.stackview.button"/>
+                                    </button>
+                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="localizables_example.stackview.textfield" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="OaA-sC-DeQ">
+                                        <rect key="frame" x="0.0" y="70.5" width="240" height="30"/>
+                                        <nil key="textColor"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits"/>
+                                    </textField>
+                                </subviews>
+                            </stackView>
                         </subviews>
                         <color key="backgroundColor" red="0.68888300657272339" green="0.71366006135940552" blue="0.73448425531387329" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="DFY-aw-5QJ" firstAttribute="centerX" secondItem="edP-8j-PzJ" secondAttribute="centerX" id="0yp-Xi-O0m"/>
                             <constraint firstItem="MAa-He-DI6" firstAttribute="centerX" secondItem="edP-8j-PzJ" secondAttribute="centerX" id="132-Wi-ZPG"/>
+                            <constraint firstItem="R2g-9P-TkA" firstAttribute="centerX" secondItem="edP-8j-PzJ" secondAttribute="centerX" id="9iN-3l-qTy"/>
                             <constraint firstItem="iQq-2y-Tdu" firstAttribute="top" secondItem="ssY-Bq-gb3" secondAttribute="bottom" constant="20" id="ACx-yA-i7y"/>
                             <constraint firstItem="iQq-2y-Tdu" firstAttribute="centerX" secondItem="edP-8j-PzJ" secondAttribute="centerX" id="JEj-Cd-GrG"/>
                             <constraint firstItem="MAa-He-DI6" firstAttribute="top" secondItem="iQq-2y-Tdu" secondAttribute="bottom" constant="20" id="JKE-bJ-5kI"/>
                             <constraint firstItem="ssY-Bq-gb3" firstAttribute="centerX" secondItem="edP-8j-PzJ" secondAttribute="centerX" id="LI8-fW-yyV"/>
+                            <constraint firstItem="R2g-9P-TkA" firstAttribute="top" secondItem="MAa-He-DI6" secondAttribute="bottom" constant="42.5" id="V4T-Sj-tfh"/>
+                            <constraint firstItem="R2g-9P-TkA" firstAttribute="width" secondItem="MAa-He-DI6" secondAttribute="width" id="gf7-ZO-T6o"/>
                             <constraint firstItem="ssY-Bq-gb3" firstAttribute="top" secondItem="DFY-aw-5QJ" secondAttribute="bottom" constant="20" id="usR-Zz-Tif"/>
                             <constraint firstItem="DFY-aw-5QJ" firstAttribute="top" secondItem="DPS-WL-2L3" secondAttribute="bottom" constant="20" id="xQq-z1-vPx"/>
                         </constraints>

--- a/SwiftyUtils Example/iOS Example/en.lproj/Localizable.strings
+++ b/SwiftyUtils Example/iOS Example/en.lproj/Localizable.strings
@@ -2,6 +2,9 @@
 "localizables_example.button" = "I am an UIButton automatically translated";
 "localizables_example.text_field" = "I am an UITextField placeholder automatically translated";
 "localizables_example.text_view" = "I am an UITextView placeholder automatically translated";
+"localizables_example.stackview.label" = "I am a label in an UIStackView";
+"localizables_example.stackview.button" = "I am a button in an UIStackView";
+"localizables_example.stackview.textfield" = "I am a textField in an UIStackView";
 
 "gestures_example.label.tap_counter" = "Tap counter: %d";
 "gestures_example.label.long_press_counter" = "Long press counter: %d";


### PR DESCRIPTION
This PR contains:
- Refactoring of `convertLocalizables`
- Renamed `convertLocalizables` into `translateSubviews`
- Add support for `UIStackView`
- Add a `UIStackView`in the example 