### PR TITLE
simplified data->[UInt8]

### DIFF
--- a/Sources/Extensions/DataExtension.swift
+++ b/Sources/Extensions/DataExtension.swift
@@ -68,15 +68,6 @@ extension Data {
     Provides the data as an array of UInt8 bytes for easy manipulation.
      */
     public var bytesArray: [UInt8] {
-        let count = self.count / MemoryLayout<UInt8>.stride
-        let array = self.withUnsafeBytes { (bytes: UnsafePointer<UInt8>) -> [UInt8] in
-            var byteArray = [UInt8]()
-            byteArray.reserveCapacity(count)
-            for index in 0..<count {
-                byteArray.append(bytes[index])
-            }
-            return byteArray
-        }
-        return array
+        return Array(self)
     }
 }


### PR DESCRIPTION
I stumbled upon a much simpler way to convert data to a UInt8 array and updated the code to accommodate. 

However, it's simplified so much that it's arguable as to whether it should even be in this framework at all. I would *personally* vouch to keep it in simply because it's not commonly documented when searching how to do this easy, one line conversion. This way, those inclined can learn from the code and everyone can benefit from a convenience function.

I'll leave it up to you though.